### PR TITLE
Bugfix: Kakao API 호출 시 에러 발생

### DIFF
--- a/src/main/kotlin/com/blife/blife/infra/external/booksearchapi/client/KakaoBookSearchClient.kt
+++ b/src/main/kotlin/com/blife/blife/infra/external/booksearchapi/client/KakaoBookSearchClient.kt
@@ -67,8 +67,14 @@ class KakaoBookSearchClient(
 
 		val resultData = responseEntity.body
 
-		return if (resultData !== null && resultData.documents.isNotEmpty())
+		if(resultData?.meta?.totalCount!! < page * 10 && page != 1L ){
+			throw TODO("데이터를 더 안가지고 오겠다")
+		}
+
+		return if (resultData.documents.isNotEmpty()) {
+
 			Pair(resultData.documents.map { it.convertToBook() }, null)
+		}
 		else
 			Pair(null, errorObject.errorCode)
 	}

--- a/src/main/kotlin/com/blife/blife/infra/external/booksearchapi/dto/kakao/KakaoBookSearchResponseDocument.kt
+++ b/src/main/kotlin/com/blife/blife/infra/external/booksearchapi/dto/kakao/KakaoBookSearchResponseDocument.kt
@@ -12,7 +12,7 @@ data class KakaoBookSearchResponseDocument(
 	val contents: String,
 	val url: String,
 	val isbn: String,
-	@JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX") val datetime: LocalDateTime,
+	@JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX") val datetime: LocalDateTime?,
 	val authors: List<String>,
 	val publisher: String,
 	val translators: List<String>,
@@ -29,11 +29,12 @@ data class KakaoBookSearchResponseDocument(
 		coverUrl = thumbnail,
 		isbn10 = getIsbn10(),
 		isbn13 = getIsbn13(),
-		publicationDate = datetime
+		publicationDate = datetime ?: LocalDateTime.now()
 	)
 
-	private fun getIsbn10(): Long {
+	private fun getIsbn10(): Long? {
 		return this.isbn.split(" ")[0]
+			.also { if(it == "") return null }
 			.filter { it.isDigit() }
 			.toLong()
 	}
@@ -41,7 +42,9 @@ data class KakaoBookSearchResponseDocument(
 	private fun getIsbn13(): Long {
 		return this.isbn.split(" ")
 			.takeIf { it.size == 2 }
-			?.let { it[1].toLong() }
+			?.let { it[1] }
+			?.filter { it.isDigit() }
+			?.toLong()
 			?: throw TODO("")
 	}
 }


### PR DESCRIPTION
closes #78 

KakaoBookSearchClient
- page와 size를 비교하여 그 이상의 값이 total값이 넘어갈 경우 데이터를 더 이상 가지고 오지 않게 수정

KakaoBookSearchResponseDocument
- ISBN10 을 가지고 올 때 공백일 경우 NULL
- ISBN13 의 경우 ISBN13내에서 문자열이 들어가는 케이스가 발견되어 숫자만 별개로 빼주는 작업 추가